### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = "g++ finalpractice.cpp"

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ Hi! Welcome to my cs1420 repo. This is more of an archive for my labs and projec
 *Please, if you're a fellow student looking for code to plagiarize, I beg you to reconsider. There a plenty of online resources that you can utilize. I recommended Stack Overflow, the reference libraries for [Java](https://docs.oracle.com/javase/8/docs/api/java/lang/ref/Reference.html), [C++](http://www.cplusplus.com/reference/), and [Python](https://docs.python.org/3/library/).*
 
 > ito
+
+[![Run on Repl.it](https://repl.it/badge/github/kidlatmc29/cs1420)](https://repl.it/github/kidlatmc29/cs1420)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. 

Trying out Repl.it's compiler since I really don't want to use the Linux server at the moment. 